### PR TITLE
Add workflow to auto-sync master from conference repo

### DIFF
--- a/.github/workflows/sync-from-conference.yml
+++ b/.github/workflows/sync-from-conference.yml
@@ -1,0 +1,39 @@
+name: Sync from conference
+
+on:
+  # Fired by Code-d-Armor/conference's "Notify website of updates" workflow
+  # whenever its master branch is updated.
+  repository_dispatch:
+    types: [conference-updated]
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout website
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch conference master
+        run: git fetch https://github.com/Code-d-Armor/conference.git master:conference-master
+
+      - name: Merge conference/master into master
+        run: |
+          if git merge-base --is-ancestor conference-master HEAD; then
+            echo "Already up to date, nothing to merge."
+            exit 0
+          fi
+          git merge --no-edit conference-master
+
+      - name: Push
+        run: git push origin HEAD:master


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/sync-from-conference.yml`
- Listens for a `repository_dispatch` event (`conference-updated`) sent by a companion workflow in `Code-d-Armor/conference` (see companion PR: https://github.com/Code-d-Armor/conference/pull/16)
- On trigger, fetches `conference`'s `master` and merges it into this repo's `master`, then pushes — automating the merge that was previously done by hand
- Also runnable manually via `workflow_dispatch`

## How it works
1. Someone pushes to `Code-d-Armor/conference`'s `master` branch
2. Conference's `notify-website.yml` workflow calls the GitHub API to dispatch a `conference-updated` event to this repo
3. This workflow receives it, merges `conference/master` in, and pushes
4. If the merge conflicts, the job fails loudly (same as a manual merge conflict would) so it can be resolved by hand

## Test plan
- [ ] Merge this PR and the companion conference PR
- [ ] Push a trivial commit to conference `master` and confirm this workflow runs and merges automatically
- [ ] Verify the existing `jekyll.yml` deploy still runs correctly on the resulting merge commit