### PR TITLE
Keep website's own .github/workflows/ authoritative during sync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.github/workflows/** merge=ours

--- a/.github/workflows/sync-from-conference.yml
+++ b/.github/workflows/sync-from-conference.yml
@@ -23,6 +23,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Keep this repo's own workflow files authoritative: conference has its
+          # own unrelated workflows (e.g. its notify-website.yml), and pushing
+          # workflow-file changes requires a permission the default token doesn't
+          # have. See .gitattributes for the merge=ours scoping.
+          git config merge.ours.driver true
 
       - name: Fetch conference master
         run: git fetch https://github.com/Code-d-Armor/conference.git master:conference-master


### PR DESCRIPTION
## Summary
Fixes the first live test run of #2, which failed:

```
! [remote rejected] HEAD -> master (refusing to allow a GitHub App to
create or update workflow .github/workflows/notify-website.yml
without workflows permission)
```

conference has its own `notify-website.yml` workflow that doesn't
belong in website and would otherwise get merged in on every sync
(and would itself try to fire dispatches back to conference's own
website-target on every website push, since it'd now exist here too).

Adds a `.gitattributes` `merge=ours` rule scoped to
`.github/workflows/**` so this repo's own workflow files always win
during the automated merge, regardless of what changes on the
conference side.

## Test plan
- [x] Confirmed the previous run failed for exactly this reason (run 29479515001)
- [ ] Merge and re-trigger `sync-from-conference.yml` via workflow_dispatch, confirm it succeeds and website's `.github/workflows/` is unchanged