### PR TITLE
Actually delete .github/workflows before restoring pre-merge state

### DIFF
--- a/.github/workflows/sync-from-conference.yml
+++ b/.github/workflows/sync-from-conference.yml
@@ -42,8 +42,9 @@ jobs:
           # here, and pushing workflow-file changes needs a permission scope
           # the default token doesn't have.
           git rm -r --cached --ignore-unmatch .github/workflows > /dev/null
+          rm -rf .github/workflows
           git checkout "$PRE_MERGE" -- .github/workflows
-          git add .github/workflows
+          git add -A .github/workflows
           if ! git diff --cached --quiet -- .github/workflows; then
             git commit --amend --no-edit
           fi


### PR DESCRIPTION
## Summary
Follow-up to #4, which still failed the same way on re-test (run 29479823155):

```
! [remote rejected] HEAD -> master (refusing to allow a GitHub App to
create or update workflow .github/workflows/notify-website.yml
without workflows permission)
```

Bug: `git checkout "$PRE_MERGE" -- .github/workflows` restores files present at that commit but doesn't delete files that only exist post-merge. The subsequent `git add .github/workflows` then re-staged the leftover `notify-website.yml` as untracked, silently undoing the intended fix.

## Fix
Add `rm -rf .github/workflows` before the checkout, so nothing is left over for `git add` to pick back up.

## Verification
Cloned the public website repo fresh into a scratch directory, fetched conference/master for real, and ran the exact shell script from the workflow file against it — confirmed `.github/workflows/` ends up exactly as website's own (no notify-website.yml) while the content change (README) still merges through, and the working tree is clean.

## Test plan
- [ ] Merge and re-trigger `sync-from-conference.yml` via workflow_dispatch, confirm success this time